### PR TITLE
Add reformatting for alphas and betas

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -9,5 +9,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "8bd47812bd957380d1f56ce1a5afb98ea2a3f788", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "6874e2aac53ba541fc944916dfa5b8f938f33af8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )


### PR DESCRIPTION
## What is the goal of this PR?

We add `pip` packages version reformatting from our (TypeDB) version
conventions to [the python
conventions](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers)
for `alpha` and `beta` releases.

## What are the changes implemented in this PR?

We update the `bazel-distribution` commit to https://github.com/typedb/bazel-distribution/commit/6874e2aac53ba541fc944916dfa5b8f938f33af8
